### PR TITLE
fix lfs checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.csv filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Using the most recent version of git lfs (3.7.1), the CSV file in this repo can't be checked out. (`git lfs clone` from readme also just clones repo without downloading the file).
So this fixes it.
See [this discussion](https://github.com/git-lfs/git-lfs/discussions/6182) for more information.
