### PR TITLE
Add .gitattributes marking MetObjects.csv as Git LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+MetObjects.csv filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Fixes #66 — MetObjects.csv is LFS-tracked but the repo ships no `filter=lfs` attribute, so `git lfs clone`/pull silently leave the 134-byte pointer (verified on git-lfs 3.7.1).

```gitattributes
MetObjects.csv filter=lfs diff=lfs merge=lfs -text
```

Verified locally: with this attribute, `git lfs pull` materializes the 317 MB CSV (sha256 matches the pointer oid).

## Related

#63 by @aomiki (opened 2026-03-29) addresses the same root cause with a broader pattern (`*.csv filter=lfs diff=lfs merge=lfs -text`). This PR is the narrower single-file variant. Either resolves the issue; pick one and close the other.